### PR TITLE
README: Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # ticker
+
+## Installation
+
+Install python3 and pip3 (e.g. `sudo apt-get install python3 python3-pip`).
+
+Afterwards, run
+
+    pip3 install django fdfgen jsonpickle
+
+You can now start a development version of the server with
+
+    python3 manage.py runserver


### PR DESCRIPTION
Add basic installation instructions. We may want to add a proper `setup.py` later.