### PR TITLE
bup: Update league_key to 2017

### DIFF
--- a/ticker/views/bup.py
+++ b/ticker/views/bup.py
@@ -202,7 +202,7 @@ def bup_list(request):
         'team_names': team_names,
         'matches': matches,
         'courts': courts,
-        'league_key': '1BL-2016',  # Fixed for now, since this information is not captured in this application
+        'league_key': '1BL-2017',  # Fixed for now, since this information is not captured in this application
     }
     return HttpResponse(json.dumps(res), content_type='application/json')
 


### PR DESCRIPTION
This key should really be determined dynamically, and should be '2BLN-2017' for BC Beuel 2.
See https://github.com/phihag/bup/blob/master/doc/data_structures.txt#L15 for a list of all possible values.