### PR TITLE
Fix django dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.10,1.11
+django>=1.11
 celery
 django-celery
 jsonpickle


### PR DESCRIPTION
With pip 9.0.1 - the current newest version - this specification is invalid. Just require 1.11 or newer.