### PR TITLE
Add a travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - "3.5"
+  - "3.6"
+
+install:
+  - pip3 install -r requirements.txt
+
+script:
+  # No tests at the moment, so just import the ticker
+  python -c 'import ticker'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.10,1.11
+django>=1.11
 celery
 django-celery
 jsonpickle


### PR DESCRIPTION
travis-ci.org automatically tests that the build works, whenever a commit is pushed into GitHub. In the future, we can add tests here as well.

Includes #10 in order to get the travis build to suceed.